### PR TITLE
Remove redundant type="text/css"

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://fonts.googleapis.com/css?family=Fira+Mono" rel="stylesheet">
-    <link href="css/style.css" rel="stylesheet" type="text/css">
+    <link href="css/style.css" rel="stylesheet">
     <link href="favicon.ico" rel="shortcut icon" type="image/x-icon">
     <title>Nano ID CC</title>
   </head>


### PR DESCRIPTION
It’s the implicit default for <link rel="stylesheet">.

https://mathiasbynens.be/notes/html5-levels#type-attributes