### PR TITLE
Change default alphabet

### DIFF
--- a/src/nano_id_cc/defaults.cljs
+++ b/src/nano_id_cc/defaults.cljs
@@ -2,7 +2,7 @@
 
 
 (def ^:const alphabet
-  "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz~")
+  "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz-")
 
 
 (def ^:const length 21)


### PR DESCRIPTION
In Nano ID 2.0 we changed default alpbahet
https://github.com/ai/nanoid/commit/22bc8fff7c6eb86426bcfc57c18c035884df023b