### PR TITLE
[FIX]:Fixed code-sample for customAlphabet

### DIFF
--- a/src/nano_id_cc/core.cljs
+++ b/src/nano_id_cc/core.cljs
@@ -64,9 +64,9 @@
     (if (not custom?)
       (str "const nanoid = require('nanoid');\n"
            "nanoid(" len "); //=> \"" id "\"")
-      (str "const generate = require('nanoid/generate');\n"
+      (str "const { customAlphabet } = require('nanoid');\n"
            "const alphabet = '" (escape alphabet) "';\n"
-           "generate(alphabet, " length "); //=> \"" id "\""))))
+           "customAlphabet(alphabet, " length "); //=> \"" id "\""))))
 
 
 (defn highlight-code []


### PR DESCRIPTION
`nanoid/generate﻿` module was deprecated in v3, as  mentioned here :point_right:  https://github.com/ai/nanoid/blob/main/CHANGELOG.md#30, the sample code being populated was outdated, hence fixed it with correct sample code for custom characters

Due to wrong sample code, some users got confused as we can see in this closed issues :point_right: https://github.com/ai/nanoid/issues/258
