### PR TITLE
Fix customAlphabet example

### DIFF
--- a/src/nano_id_cc/core.cljs
+++ b/src/nano_id_cc/core.cljs
@@ -66,7 +66,8 @@
            "nanoid(" len "); //=> \"" id "\"")
       (str "const { customAlphabet } = require('nanoid');\n"
            "const alphabet = '" (escape alphabet) "';\n"
-           "customAlphabet(alphabet, " length "); //=> \"" id "\""))))
+           "const nanoid = customAlphabet(alphabet, " length ");\n"
+           "nanoid()//=> \"" id "\""))))
 
 
 (defn highlight-code []

--- a/src/nano_id_cc/core.cljs
+++ b/src/nano_id_cc/core.cljs
@@ -67,7 +67,7 @@
       (str "const { customAlphabet } = require('nanoid');\n"
            "const alphabet = '" (escape alphabet) "';\n"
            "const nanoid = customAlphabet(alphabet, " length ");\n"
-           "nanoid()//=> \"" id "\""))))
+           "nanoid() //=> \"" id "\""))))
 
 
 (defn highlight-code []


### PR DESCRIPTION
`customAlphabet()` returns a function, not a ID